### PR TITLE
Windows error 1224

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,7 @@ jobs:
         config:
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release'}
+          - {os: windows-latest, r: 'release'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workspace
 Title: Workspace and Data Management Tools
-Version: 0.1.1
+Version: 0.1.1.0001
 Authors@R: c(
     person("David", "Gohel", , "david.gohel@ardata.fr", role = c("aut", "cre")),
     person("ArData", role = "cph")

--- a/R/readers.R
+++ b/R/readers.R
@@ -45,7 +45,7 @@ read_dataset_in_workspace <- function(x, name) {
     cli_abort("Value of {.code name} is not unique in workspace.")
   }
   file <- file.path(x$dir, objs$file)
-  read_parquet(file)
+  read_parquet(file, mmap = FALSE)
 }
 
 #' @export

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -26,7 +26,7 @@ read_objects_description <- function(x) {
     x$dir,
     paste0(.datasets_description, ".parquet")
   )
-  read_parquet(file_objects_description)
+  read_parquet(file_objects_description, mmap = FALSE)
 }
 
 create_datasets_folder <- function(x) {
@@ -200,7 +200,7 @@ unpack_workspace <- function(file) {
       dir,
       paste0(.datasets_description, ".parquet")
     )
-    objects_desc <- read_parquet(file_datasets_description)
+    objects_desc <- read_parquet(file_datasets_description, mmap = FALSE)
     unlink(file_datasets_description, force = TRUE)
     x <- as_workspace_structure(
       dir = dir,


### PR DESCRIPTION
Fix error when using `store_dataset()` on windows causing error  

```simpleError: IOError: Failed to open local file 'C:/Users/EliDaniels/AppData/Local/Temp/RtmpU7p9u5/ws652c38bf86f/dataset_description.parquet'. Detail: [Windows error 1224] The requested operation cannot be performed on a file with a user-mapped section open.```

Setting `mmap` argument of `arrow::read_parquet() ` to `FALSE` fixes it. Seems to be related to this issue: https://github.com/apache/arrow/issues/41714